### PR TITLE
Update demo

### DIFF
--- a/test/test_vsm_box_pubdictionaries.html
+++ b/test/test_vsm_box_pubdictionaries.html
@@ -2,9 +2,11 @@
 <html lang="English">
 <head>
     <title>vsm-box + PubDictionaries example</title>
-    <script src="../dist/vsm-pubdictionaries.min.js"></script>
+
+    <!-- <script src="../dist/vsm-pubdictionaries.min.js"></script> -->
     <!-- To use the above line, run first `npm build`. The below line can be used anytime :) -->
-    <!-- <script src="https://unpkg.com/vsm-pubdictionaries@^1.0.0/dist/vsm-pubdictionaries.min.js"></script> -->
+    <script src="https://unpkg.com/vsm-pubdictionaries@^1.0.0/dist/vsm-pubdictionaries.min.js"></script>
+
     <script src="https://unpkg.com/vsm-dictionary-rnacentral@^1.0.1/dist/vsm-dictionary-rnacentral.min.js"></script>
     <script src="https://unpkg.com/vsm-dictionary-cacher@^1.2.0/dist/vsm-dictionary-cacher.min.js"></script>
     <script src="https://unpkg.com/vsm-dictionary-combiner@^1.0.1/dist/vsm-dictionary-combiner.min.js"></script>


### PR DESCRIPTION
Suggesting to make the `unpkg` version active by default, instead of the `npm build` one,
in order to have a demo that works out-of-the-box for first-time visitors.

Also added newlines around the 'choice section' so it stands out more clearly.